### PR TITLE
Add years for recent preprints

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -2,12 +2,14 @@
   title: On the generalized Fermat equation x<sup>13</sup> + y<sup>13</sup> = z<sup>n</sup>
   coauthors: [dahmen, freitas]
   published: false
+  year: 2025
   arxiv: 2510.12092
 
 - id: aristotle
   title: 'Aristotle: IMO-level Automated Theorem Proving'
   coauthors: [achim, bietti, der, federico, gukov, halpern-leistner, henningsgard, kudryashov, meiburg, michelsen, patterson, rodriguez, scharff, shanker, sicca, sowrirajan, swope, tamas, tenev, thomm, harold-williams, lawrence-wu]
   published: false
+  year: 2025
   arxiv: 2510.01346
 
 - id: flt-regular-ii


### PR DESCRIPTION
### Motivation
- Ensure recent preprints render a year in the publications list by adding missing `year` metadata for two recent entries.

### Description
- Add `year: 2025` to the `_data/publications.yml` entries `fermat-13` and `aristotle` so the site can display their year.

### Testing
- Ran `git diff --check` and validated the YAML with `ruby -e 'require "yaml"; data = YAML.load_file("_data/publications.yml"); abort "bad fermat-13 year" unless data[0]["year"] == 2025; abort "bad aristotle year" unless data[1]["year"] == 2025; puts "Validated publication years: #{data[0]["id"]} #{data[0]["year"]}, #{data[1]["id"]} #{data[1]["year"]}"'` which succeeded, and note that `bundle exec jekyll build` could not be run in this environment because there is no `Gemfile`/`.bundle` present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ed3f98e6c832d8bf754ecaefc796f)